### PR TITLE
Fix Typo in CameraBridgeViewBase error message

### DIFF
--- a/opencvandroidlib/src/main/java/org/opencv/android/CameraBridgeViewBase.java
+++ b/opencvandroidlib/src/main/java/org/opencv/android/CameraBridgeViewBase.java
@@ -361,7 +361,7 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
         if (!connectCamera(getWidth(), getHeight())) {
             AlertDialog ad = new AlertDialog.Builder(getContext()).create();
             ad.setCancelable(false); // This blocks the 'BACK' button
-            ad.setMessage("It seems that you device does not support camera (or it is locked). Application will be closed.");
+            ad.setMessage("It seems that your device does not support camera (or it is locked). Application will be closed.");
             ad.setButton(DialogInterface.BUTTON_NEUTRAL,  "OK", new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.dismiss();


### PR DESCRIPTION
Fix Typo in CameraBridgeViewBase error message - change "you device" to "your device"